### PR TITLE
Revert "Cryptohash is deprecated. Use Cryptonite instead."

### DIFF
--- a/Flatr-App-Core.cabal
+++ b/Flatr-App-Core.cabal
@@ -36,7 +36,7 @@ executable Flatr-App-Core-exe
                      , word8
                      , bytestring
                      , base16-bytestring >=0.1
-                     , cryptonite >=0.24
+                     , cryptohash >=0.11
   default-language:    Haskell2010
 
 source-repository head

--- a/Flatr-App-Core.nix
+++ b/Flatr-App-Core.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, base, base16-bytestring, bytestring
-, configurator, containers, cryptonite, http-types
+, configurator, containers, cryptohash, http-types
 , hvect, jwt, monad-logger, mtl, persistent, persistent-sqlite
 , persistent-template, random, Spock, stdenv, text, time
 , transformers, word8, iso8601-time
@@ -16,7 +16,7 @@ mkDerivation {
   libraryHaskellDepends = [ base ];
   executableHaskellDepends = [
     aeson base base16-bytestring bytestring configurator containers
-    cryptonite http-types hvect jwt monad-logger mtl persistent
+    cryptohash http-types hvect jwt monad-logger mtl persistent
     persistent-sqlite persistent-template random Spock text time
     transformers word8 iso8601-time
 

--- a/app/Util.hs
+++ b/app/Util.hs
@@ -9,8 +9,7 @@ module Util where
 import           Control.Arrow
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger    (LoggingT, runStdoutLoggingT)
-import qualified Crypto.KDF.Argon2       as Ar2
-import           Crypto.Error            (throwCryptoError)
+import qualified Crypto.Hash.SHA512      as SHA
 import           Data.Aeson              hiding (json)
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Base16  as B16
@@ -43,8 +42,7 @@ decodeHex = fst . B16.decode . E.encodeUtf8
 
 hashPassword :: T.Text -> BS.ByteString -> T.Text
 hashPassword password salt =
-    makeHex . throwCryptoError $ Ar2.hash Ar2.defaultOptions (E.encodeUtf8 password) salt 1024
-    -- throwCryptoError can in theory throw, crashing the program. But this will happen only if salt length or output size are invalid. As this will never be the case (as long as we provide acceptable salts), this will never happen.
+     makeHex . SHA.finalize $ SHA.updates SHA.init [salt, E.encodeUtf8 password]
 
 runSQL
   :: (HasSpock m, SpockConn m ~ SqlBackend)


### PR DESCRIPTION
Reverts flatrapp/core#1

Doesn't work on NixOS - can't figure out why, right now.
`cabal install --dependencies-only` is not an option on NixOS. That's only a workaround.