### PR TITLE
Revert "Revert "Cryptohash is deprecated. Use Cryptonite instead.""

### DIFF
--- a/Flatr-App-Core.cabal
+++ b/Flatr-App-Core.cabal
@@ -36,8 +36,7 @@ executable Flatr-App-Core-exe
                      , word8
                      , bytestring
                      , base16-bytestring >=0.1
-                     , cryptohash >=0.11
-                     , cryptonite
+                     , cryptonite >=0.22
   default-language:    Haskell2010
 
 source-repository head

--- a/Flatr-App-Core.nix
+++ b/Flatr-App-Core.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, base, base16-bytestring, bytestring
-, configurator, containers, cryptohash, http-types
+, configurator, containers, cryptonite, http-types
 , hvect, jwt, monad-logger, mtl, persistent, persistent-sqlite
 , persistent-template, random, Spock, stdenv, text, time
 , transformers, word8, iso8601-time
@@ -16,7 +16,7 @@ mkDerivation {
   libraryHaskellDepends = [ base ];
   executableHaskellDepends = [
     aeson base base16-bytestring bytestring configurator containers
-    cryptohash http-types hvect jwt monad-logger mtl persistent
+    cryptonite http-types hvect jwt monad-logger mtl persistent
     persistent-sqlite persistent-template random Spock text time
     transformers word8 iso8601-time
 

--- a/app/Util.hs
+++ b/app/Util.hs
@@ -9,7 +9,7 @@ module Util where
 import           Control.Arrow
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger      (LoggingT, runStdoutLoggingT)
-import qualified Crypto.Hash.SHA512        as SHA
+import qualified Crypto.KDF.Argon2       as Ar2
 import           Data.Aeson                ( FromJSON
                                            , object
                                            , (.=)
@@ -48,7 +48,8 @@ decodeHex = fst . B16.decode . E.encodeUtf8
 
 hashPassword :: T.Text -> BS.ByteString -> T.Text
 hashPassword password salt =
-     makeHex . SHA.finalize $ SHA.updates SHA.init [salt, E.encodeUtf8 password]
+    makeHex . throwCryptoError $ Ar2.hash Ar2.defaultOptions (E.encodeUtf8 password) salt 1024
+    -- throwCryptoError can in theory throw, crashing the program. But this will happen only if salt length or output size are invalid. As this will never be the case (as long as we provide acceptable salts), this will never happen.
 
 runSQL
   :: (HasSpock m, SpockConn m ~ SqlBackend)

--- a/app/Util.hs
+++ b/app/Util.hs
@@ -9,7 +9,8 @@ module Util where
 import           Control.Arrow
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger      (LoggingT, runStdoutLoggingT)
-import qualified Crypto.KDF.Argon2       as Ar2
+import qualified Crypto.KDF.Argon2         as Ar2
+import           Crypto.Error              (throwCryptoError)
 import           Data.Aeson                ( FromJSON
                                            , object
                                            , (.=)


### PR DESCRIPTION
The problem from #4 can be fixed by requiring at least cryptonite 0.22 instead of at least cryptonite 0.24 because NixOS 17.09 does only provide cryptonite 0.23.

Keep in mind that this is a breaking change. Users have to be recreated.